### PR TITLE
Remove the quotation around the boundary value in Content-Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ print(multipartFormData.header.name)
 // Content-Type
 
 print(multipartFormData.header.value)
-// multipart/form-data; boundary="boundary"
+// multipart/form-data; boundary=boundary
 
 switch multipartFormData.asData() {
 case let .valid(data):

--- a/Sources/MultipartFormDataKit/MultipartFormData.swift
+++ b/Sources/MultipartFormDataKit/MultipartFormData.swift
@@ -13,14 +13,8 @@ import Foundation
 // boundary.
 public struct MultipartFormData {
     public var header: ContentType.Header {
-        return .from(
-            mimeType: .multipartFormData,
-            parameters: [
-                ContentType.Parameter(
-                    attribute: "boundary",
-                    value: self.uniqueAndValidLengthBoundary
-                ),
-            ]
+        .init(
+            representing: "\(MIMEType.multipartFormData.text); boundary=\(uniqueAndValidLengthBoundary)"
         )
     }
 

--- a/Tests/MultipartFormDataKitTests/MultipartFormDataBuilderTests.swift
+++ b/Tests/MultipartFormDataKitTests/MultipartFormDataBuilderTests.swift
@@ -37,7 +37,7 @@ class MultipartFormDataBuilderTests: XCTestCase {
 
         XCTAssertEqual(
             multipartFormData.contentType,
-            "multipart/form-data; boundary=\"boundary\""
+            "multipart/form-data; boundary=boundary"
         )
         XCTAssertEqual(
             String(data: multipartFormData.body, encoding: .utf8)!,


### PR DESCRIPTION
The library quotes the boundary value in the Content-Type header, but there are some server-side library that cannot parse this. For example, [swifter](https://github.com/httpswift/swifter).

Alamofire also does not quote: https://github.com/Alamofire/Alamofire/blob/bdecb2c87a21a236dcfe88b21532ad3f0e3d20f4/Source/MultipartFormData.swift#L100

Would it be possible to removing it?
